### PR TITLE
Add vocab platform rules

### DIFF
--- a/entrypoints/content/vocab-label/__tests__/platform-rules.test.ts
+++ b/entrypoints/content/vocab-label/__tests__/platform-rules.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getActivePlatformRule } from '../platform-rules'
+
+function setupDOM(html: string): void {
+  document.body.innerHTML = html
+}
+
+describe('vocab platform rules', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('collects only tweet text blocks on X', () => {
+    setupDOM(`
+      <main>
+        <article>
+          <div data-testid="User-Name">Mike Chong</div>
+          <div data-testid="tweetText">Ubiquitous article content.</div>
+          <div data-testid="like">Like</div>
+        </article>
+        <article>
+          <div data-testid="tweetText">Quoted phenomenon appears here.</div>
+        </article>
+      </main>
+    `)
+
+    const rule = getActivePlatformRule('x.com')
+    const main = document.querySelector('main') as Element
+    const blocks = rule?.collectBlocks(main) ?? []
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks.every(block => block.getAttribute('data-testid') === 'tweetText')).toBe(true)
+    expect(blocks.map(block => block.textContent)).toEqual([
+      'Ubiquitous article content.',
+      'Quoted phenomenon appears here.',
+    ])
+  })
+
+  it('finds the nearest tweet text block from a nested mutation target', () => {
+    setupDOM(`
+      <article>
+        <div data-testid="tweetText">
+          <span><strong>Nested ubiquitous content.</strong></span>
+        </div>
+      </article>
+    `)
+
+    const rule = getActivePlatformRule('twitter.com')
+    const nested = document.querySelector('strong') as Element
+    const blocks = rule?.collectBlocks(nested) ?? []
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].getAttribute('data-testid')).toBe('tweetText')
+  })
+
+  it('does not match unrelated hosts', () => {
+    expect(getActivePlatformRule('example.com')).toBeNull()
+  })
+})

--- a/entrypoints/content/vocab-label/platform-rules.ts
+++ b/entrypoints/content/vocab-label/platform-rules.ts
@@ -1,0 +1,55 @@
+export interface VocabPlatformRule {
+  name: string
+  match: (hostname: string) => boolean
+  resolveContentRoot?: () => Element | null
+  collectBlocks: (root: Element) => Element[]
+}
+
+function isXHost(hostname: string): boolean {
+  return hostname === 'x.com' || hostname.endsWith('.x.com')
+    || hostname === 'twitter.com' || hostname.endsWith('.twitter.com')
+}
+
+function uniqueElements(elements: Element[]): Element[] {
+  const seen = new Set<Element>()
+  const result: Element[] = []
+
+  for (const el of elements) {
+    if (!el.isConnected || seen.has(el)) continue
+    seen.add(el)
+    result.push(el)
+  }
+
+  return result
+}
+
+const X_TWEET_TEXT_SELECTOR = '[data-testid="tweetText"]'
+
+const X_PLATFORM_RULE: VocabPlatformRule = {
+  name: 'x',
+  match: isXHost,
+  resolveContentRoot: () => document.querySelector('main') ?? document.body,
+  collectBlocks: root => {
+    const candidates: Element[] = []
+    const closestTweetText = root.closest(X_TWEET_TEXT_SELECTOR)
+
+    if (closestTweetText) {
+      candidates.push(closestTweetText)
+    }
+
+    if (root.matches(X_TWEET_TEXT_SELECTOR)) {
+      candidates.push(root)
+    }
+
+    candidates.push(...Array.from(root.querySelectorAll(X_TWEET_TEXT_SELECTOR)))
+    return uniqueElements(candidates)
+  },
+}
+
+const PLATFORM_RULES: VocabPlatformRule[] = [
+  X_PLATFORM_RULE,
+]
+
+export function getActivePlatformRule(hostname = window.location.hostname): VocabPlatformRule | null {
+  return PLATFORM_RULES.find(rule => rule.match(hostname)) ?? null
+}


### PR DESCRIPTION
## Summary
- Add a platform-rule layer for vocabulary labeling.
- Add X/Twitter support that collects only `data-testid=\"tweetText\"` blocks.
- Cover X platform block collection with unit tests.

## Test plan
- npm test -- entrypoints/content/vocab-label/__tests__/platform-rules.test.ts


Made with [Cursor](https://cursor.com)