### PR TITLE
Fix X vocabulary annotation scope

### DIFF
--- a/entrypoints/content/vocab-label/__tests__/annotate.test.ts
+++ b/entrypoints/content/vocab-label/__tests__/annotate.test.ts
@@ -220,6 +220,53 @@ describe('annotateVisibleText — reverse-order DOM mutation', () => {
     expect(annotatedWords).toContain('ubiquitous')
   })
 
+  it('skips unknown proper-name-like words and acronyms', async () => {
+    setupDOM('<p>Mike Chong met NASA while discussing ubiquitous research.</p>')
+
+    mockSendMessage.mockImplementation(async (msg: any) => {
+      if (msg.type !== 'CONTEXT_GLOSS') return { success: false }
+      return {
+        success: true,
+        data: { gloss: '释义', source: 'llm' },
+      }
+    })
+
+    const ctx = makeCtx()
+
+    await annotateVisibleText(ctx)
+
+    const annotatedWords = Array.from(document.querySelectorAll('ruby[data-ann-vocab]'))
+      .map(r => r.firstChild?.textContent?.toLowerCase())
+    const llmWords = mockSendMessage.mock.calls
+      .filter((c: any[]) => c[0]?.type === 'CONTEXT_GLOSS')
+      .map((c: any[]) => c[0].word.toLowerCase())
+
+    expect(annotatedWords).not.toContain('mike')
+    expect(annotatedWords).not.toContain('chong')
+    expect(annotatedWords).not.toContain('nasa')
+    expect(llmWords).not.toContain('mike')
+    expect(llmWords).not.toContain('chong')
+    expect(llmWords).not.toContain('nasa')
+    expect(annotatedWords).toContain('ubiquitous')
+  })
+
+  it('keeps capitalized words that already exist in the user snapshot', async () => {
+    setupDOM('<p>Zephyr arrived today.</p>')
+
+    const snapshot = makeSnapshot({
+      zephyr: { proficiency: 1, exp: '西风' },
+    })
+
+    const ctx = makeCtx({ snapshot })
+
+    await annotateVisibleText(ctx)
+
+    const annotatedWords = Array.from(document.querySelectorAll('ruby[data-ann-vocab]'))
+      .map(r => r.firstChild?.textContent?.toLowerCase())
+
+    expect(annotatedWords).toContain('zephyr')
+  })
+
   it('restricts annotation to the provided content root', async () => {
     setupDOM(`
             <nav>Extraordinary nav item appears here.</nav>

--- a/entrypoints/content/vocab-label/annotate.ts
+++ b/entrypoints/content/vocab-label/annotate.ts
@@ -114,6 +114,27 @@ function getSentenceContext(textNode: Text): string {
   return text
 }
 
+function isAtSentenceStart(text: string, startOffset: number): boolean {
+  const before = text.slice(0, startOffset).trim()
+  return before.length === 0 || /[.!?]\s*$/.test(before)
+}
+
+function hasAdjacentTitleCaseToken(text: string, startOffset: number, endOffset: number): boolean {
+  const before = text.slice(0, startOffset)
+  const after = text.slice(endOffset)
+  return /[A-Z][a-z]+[\s'-]+$/.test(before) || /^[\s'-]+[A-Z][a-z]+/.test(after)
+}
+
+function isLikelyProperNounCandidate(word: string, text: string, startOffset: number, endOffset: number): boolean {
+  if (/^[A-Z]{2,}$/.test(word)) return true
+  if (/[a-z][A-Z]/.test(word)) return true
+
+  if (!/^[A-Z][a-z]+$/.test(word)) return false
+
+  if (hasAdjacentTitleCaseToken(text, startOffset, endOffset)) return true
+  return !isAtSentenceStart(text, startOffset)
+}
+
 async function resolveGloss(word: string, sentence: string): Promise<GlossResult | null> {
   try {
     const res = await MessageUtils.sendMessage({
@@ -295,6 +316,8 @@ function collectMatches(textNode: Text, ctx: AnnotationContext, pending: Pending
 
     const entry = ctx.snapshot.entries[wordNorm]
     if (entry && entry.proficiency >= ctx.masteryThreshold) continue
+
+    if (!entry && isLikelyProperNounCandidate(word, text, match.index, match.index + word.length)) continue
 
     if (!entry && shouldFilterByLevel(wordNorm, ctx.userCEFRLevel)) continue
 

--- a/entrypoints/content/vocab-label/index.ts
+++ b/entrypoints/content/vocab-label/index.ts
@@ -2,6 +2,7 @@ import { isEnglishPage, shouldAnnotateDomain } from './detect-page'
 import { injectVocabStyles, removeVocabStyles } from './styles'
 import { annotateVisibleText, cleanupAnnotations, resetVocabLabelRuntimeState } from './annotate'
 import { collectAnnotatableBlocks, resolveContentRoot, ANNOTATABLE_BLOCK_SELECTOR, isExcludedSection } from './content-scope'
+import { getActivePlatformRule, type VocabPlatformRule } from './platform-rules'
 import { isElementWithinViewportWindow } from './viewport'
 import { Logger } from '../../../utils/logger'
 import MessageUtils from '../../../utils/message'
@@ -14,6 +15,7 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null
 let idleHandle: ReturnType<typeof setTimeout> | number | null = null
 let isFlushing = false
 let activeContentRoot: Element | null = null
+let activePlatformRule: VocabPlatformRule | null = null
 let rootRecheckTimers: ReturnType<typeof setTimeout>[] = []
 let allowRootFallbackToContentRoot = true
 let viewportReconcileTimer: ReturnType<typeof setTimeout> | null = null
@@ -115,6 +117,18 @@ function enqueueBlocks(blocks: Iterable<Element>): void {
   }
 }
 
+function resolveActiveContentRoot(): Element {
+  return activePlatformRule?.resolveContentRoot?.() ?? resolveContentRoot()
+}
+
+function collectActiveAnnotatableBlocks(root: Element): Element[] {
+  if (activePlatformRule) {
+    return activePlatformRule.collectBlocks(root).filter(block => !isExcludedSection(block))
+  }
+
+  return collectAnnotatableBlocks(root)
+}
+
 function observeBlock(block: Element): void {
   if (!visibilityObserver) return
   if (observedBlocks.has(block)) return
@@ -125,7 +139,7 @@ function observeBlock(block: Element): void {
 
 function reconcileVisibleBlocks(): void {
   if (!activeContentRoot) return
-  const visibleBlocks = collectAnnotatableBlocks(activeContentRoot).filter(block => isElementWithinViewportWindow(block, 0.5))
+  const visibleBlocks = collectActiveAnnotatableBlocks(activeContentRoot).filter(block => isElementWithinViewportWindow(block, 0.5))
   for (const block of visibleBlocks) {
     observeBlock(block)
   }
@@ -159,6 +173,14 @@ function removeViewportListeners(): void {
 
 function collectBlocksFromNode(node: Node): Element[] {
   if (!activeContentRoot) return []
+
+  if (activePlatformRule) {
+    const element = node.nodeType === Node.TEXT_NODE ? node.parentElement : node instanceof Element ? node : null
+    if (!element || !activeContentRoot.contains(element)) return []
+    return activePlatformRule.collectBlocks(element)
+      .filter(block => activeContentRoot?.contains(block))
+      .filter(block => !isExcludedSection(block))
+  }
 
   const collected = new Set<Element>()
 
@@ -231,8 +253,8 @@ function setupVisibilityObserver(root: Element): void {
     },
   )
 
-  const blocks = collectAnnotatableBlocks(root)
-  allowRootFallbackToContentRoot = blocks.length === 1 && blocks[0] === root
+  const blocks = collectActiveAnnotatableBlocks(root)
+  allowRootFallbackToContentRoot = !activePlatformRule && blocks.length === 1 && blocks[0] === root
 
   for (const block of blocks) {
     observeBlock(block)
@@ -245,7 +267,7 @@ function refreshContentRootIfNeeded(force = false): void {
   if (!activeContentRoot) return
   if (!force && activeContentRoot !== document.body && activeContentRoot.isConnected) return
 
-  const nextRoot = resolveContentRoot()
+  const nextRoot = resolveActiveContentRoot()
   if (!nextRoot || nextRoot === activeContentRoot) return
 
   activeContentRoot = nextRoot
@@ -346,11 +368,12 @@ export async function initVocabLabel(): Promise<void> {
 
   isRunning = true
   injectVocabStyles()
+  activePlatformRule = getActivePlatformRule()
 
   const emptySnapshot: VocabSnapshot = { version: '1.0', updatedAt: 0, entries: {} }
   const normalizedMaxAnnotations = Number.isFinite(config.maxAnnotationsPerPage) && config.maxAnnotationsPerPage > 0 ? config.maxAnnotationsPerPage : 200
 
-  activeContentRoot = resolveContentRoot()
+  activeContentRoot = resolveActiveContentRoot()
   annotateCtx = {
     snapshot: snapshot ?? emptySnapshot,
     masteryThreshold: config.masteryThreshold,
@@ -361,7 +384,7 @@ export async function initVocabLabel(): Promise<void> {
 
   Logger.info('[VocabLabel] Starting annotation with strict content root...')
 
-  const initialBlocks = collectAnnotatableBlocks(activeContentRoot).filter(block => isElementWithinViewportWindow(block, 0.5))
+  const initialBlocks = collectActiveAnnotatableBlocks(activeContentRoot).filter(block => isElementWithinViewportWindow(block, 0.5))
 
   const initialCount = await annotateVisibleText(annotateCtx, {
     roots: initialBlocks,
@@ -400,6 +423,7 @@ export function destroyVocabLabel(): void {
   cancelScheduledFlush()
   pendingBlocks.clear()
   activeContentRoot = null
+  activePlatformRule = null
   annotateCtx = null
   allowRootFallbackToContentRoot = true
 


### PR DESCRIPTION
## Summary
- Apply platform-specific vocab block collection so X annotation targets tweet text instead of surrounding UI chrome.
- Skip unknown proper-name-like words and acronyms while preserving user snapshot entries.
- Add regression coverage for proper noun filtering and snapshot overrides.

## Test plan
- npm test -- entrypoints/content/vocab-label/__tests__/annotate.test.ts entrypoints/content/vocab-label/__tests__/platform-rules.test.ts entrypoints/content/vocab-label/__tests__/content-scope.test.ts entrypoints/content/vocab-label/__tests__/frequency-filter.test.ts


Made with [Cursor](https://cursor.com)