### PR TITLE
chore: reduce GitHub Actions storage usage

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -5,11 +5,19 @@ on:
   workflow_call:
     outputs:
       artifact-name:
-        description: "Name of the uploaded artifact"
+        description: 'Name of the uploaded artifact'
         value: ${{ jobs.build.outputs.artifact-name }}
       zip-name:
-        description: "Chrome Web Store package file name"
+        description: 'Chrome Web Store package file name'
         value: ${{ jobs.build.outputs.zip-name }}
+
+permissions:
+  artifact-metadata: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -26,7 +34,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -58,7 +65,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.package_meta.outputs.artifact-name }}
-          path: .output/chrome-mv3/
+          path: .output/${{ steps.package_meta.outputs.zip-name }}
           if-no-files-found: error
-          retention-days: 30
-          include-hidden-files: true 
+          retention-days: 1

--- a/.github/workflows/cleanup-actions-storage.yml
+++ b/.github/workflows/cleanup-actions-storage.yml
@@ -1,0 +1,85 @@
+name: Cleanup Actions Storage
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_retention_days:
+        description: 'Delete workflow artifacts older than this many days; 0 deletes all artifacts'
+        required: true
+        default: '1'
+      delete_caches:
+        description: 'Delete all GitHub Actions dependency caches'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  actions: write
+  artifact-metadata: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete expired artifacts and optional caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_RETENTION_DAYS: ${{ inputs.artifact_retention_days }}
+          DELETE_CACHES: ${{ inputs.delete_caches }}
+        run: |
+          set -euo pipefail
+
+          case "$ARTIFACT_RETENTION_DAYS" in
+            ''|*[!0-9]*)
+              echo "::error::artifact_retention_days must be a non-negative integer"
+              exit 1
+              ;;
+          esac
+
+          cutoff_epoch="$(date -u -d "${ARTIFACT_RETENTION_DAYS} days ago" +%s)"
+          deleted_artifacts=0
+          artifact_rows="$(
+            gh api --paginate "repos/${REPO}/actions/artifacts?per_page=100" \
+              --jq '.artifacts[] | [.id, .name, .created_at] | @tsv'
+          )"
+
+          if [[ -n "$artifact_rows" ]]; then
+            while IFS=$'\t' read -r artifact_id artifact_name created_at; do
+              created_epoch="$(date -u -d "$created_at" +%s)"
+              if (( created_epoch < cutoff_epoch )); then
+                echo "Deleting artifact ${artifact_id}: ${artifact_name} (${created_at})"
+                gh api --method DELETE "repos/${REPO}/actions/artifacts/${artifact_id}"
+                deleted_artifacts=$((deleted_artifacts + 1))
+              fi
+            done <<< "$artifact_rows"
+          fi
+
+          echo "Deleted ${deleted_artifacts} artifact(s)."
+
+          if [[ "$DELETE_CACHES" != "true" ]]; then
+            echo "Skipped cache cleanup."
+            exit 0
+          fi
+
+          deleted_caches=0
+          cache_rows="$(
+            gh api --paginate "repos/${REPO}/actions/caches?per_page=100" \
+              --jq '.actions_caches[] | [.id, .key, .ref, .last_accessed_at] | @tsv'
+          )"
+
+          if [[ -n "$cache_rows" ]]; then
+            while IFS=$'\t' read -r cache_id cache_key cache_ref last_accessed_at; do
+              echo "Deleting cache ${cache_id}: ${cache_key} (${cache_ref}, last accessed ${last_accessed_at})"
+              gh api --method DELETE "repos/${REPO}/actions/caches/${cache_id}"
+              deleted_caches=$((deleted_caches + 1))
+            done <<< "$cache_rows"
+          fi
+
+          echo "Deleted ${deleted_caches} cache(s)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - 'v*' # eg：v2.0.0
 
+permissions:
+  actions: read
+  artifact-metadata: read
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/build-extension.yml
@@ -21,12 +30,11 @@ jobs:
           name: ${{ needs.build.outputs.artifact-name }}
           path: ./release-assets
 
-      - name: Package release asset
+      - name: Verify release asset
         run: |
           set -euo pipefail
-          test -f ./release-assets/manifest.json
-          (cd ./release-assets && zip -qr "../${{ needs.build.outputs.zip-name }}" .)
-          unzip -l "./${{ needs.build.outputs.zip-name }}" manifest.json
+          test -f "./release-assets/${{ needs.build.outputs.zip-name }}"
+          unzip -l "./release-assets/${{ needs.build.outputs.zip-name }}" manifest.json
 
       - name: Extract version from tag
         id: get_version
@@ -48,6 +56,6 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          files: ./${{ needs.build.outputs.zip-name }}
+          files: ./release-assets/${{ needs.build.outputs.zip-name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ annhub/
 │   ├── eudic-openapi.ts            # 欧路 API 封装（fetchCategories, fetchAllWords）
 │   ├── message/index.ts            # 消息发送/创建工具
 │   └── logger.ts                   # 日志工具
+├── .github/workflows/              # GitHub Actions：扩展构建、发布、Actions storage 清理
 ├── e2e/                            # Playwright E2E 测试
 │   ├── fixtures.ts                 # 自定义 fixture（扩展加载）
 │   ├── helpers.ts                  # 辅助函数（service worker 交互、导航）
@@ -246,6 +247,15 @@ Content Script 与 Background Service Worker 通过 `chrome.runtime.sendMessage`
 | `Esc` | 全平台 | 退出 Mode B / 关闭备注输入 |
 | `Enter` | 全平台 | 提交备注 |
 
+### 5.9 GitHub Actions Storage 策略
+
+`.github/workflows/` 维护扩展构建、发布与 Actions storage 清理：
+
+- `build-extension.yml`：`workflow_dispatch` / `workflow_call` 构建 Chrome MV3 扩展，执行 `npm ci`、`npm run compile`、`npm run zip`；只上传 `.output/{package-name}-{version}-chrome.zip` 作为 workflow 间传递 artifact，`retention-days: 1`
+- `release.yml`：tag `v*` 触发，复用 `build-extension.yml`，下载 zip 后直接校验并上传到 GitHub Release；不再重新打包下载到的目录
+- `cleanup-actions-storage.yml`：手动触发，用 `GITHUB_TOKEN` 删除超过输入天数的 workflow artifacts，并可选择删除所有 Actions dependency caches
+- 构建 workflow 不启用 `actions/setup-node` 的 npm cache；release 通常跑在 tag ref 上，cache 复用价值低且会占用 Actions cache storage
+
 ---
 
 ## 六、测试
@@ -306,3 +316,4 @@ npx playwright test
 8. **服务重启**：`restartServices()` 先调用各 service 的 `cleanup()`，再以 `forceReinitialize` 模式重新初始化
 9. **生词标注**：操作宿主 DOM（非 Shadow Root），标记 `data-ann-vocab="1"`，支持 `cleanupAnnotations()` 回收
 10. **LLM 配置**：`getLlmConfig()` 采用非空值优先 merge，空字符串和 `undefined` 不覆盖已有存储值
+11. **Actions storage 控制**：临时构建 artifact 只保留 1 天，发布包以 GitHub Release asset 为准；不要在 release/tag 构建中恢复 npm cache，历史 artifacts/caches 通过手动 `Cleanup Actions Storage` workflow 清理

--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ npm run website:start
 ### 文档网站
 - 构建输出: `website/.next/`
 
+## GitHub Actions 与存储费用
+
+- `Build Extension` workflow 只上传 `.output/{package-name}-{version}-chrome.zip`，artifact 保留 1 天，用于 workflow 间传递。
+- `Release Extensions` workflow 在 `v*` tag 上复用构建 workflow，下载 zip 后直接作为 GitHub Release asset 发布；长期下载入口是 Release，不是 Actions artifact。
+- 构建 workflow 不启用 npm Actions cache，避免 tag/ref 维度缓存长期占用 Actions cache storage。
+- 如需清理历史占用，在 GitHub Actions 手动运行 `Cleanup Actions Storage` workflow，可删除超过指定天数的 artifacts，并可删除 Actions dependency caches。
+
 ## 技术栈
 
 ### 扩展


### PR DESCRIPTION
Reduces Actions storage by uploading only the extension zip with 1-day retention, disabling npm cache for the release build path, and adding a manual cleanup workflow for old artifacts/caches. Validation: npm run compile; npm run zip; unzip manifest check; workflow YAML parse; workflow YAML Prettier check; git diff --check origin/main..HEAD.